### PR TITLE
Improve category form with dynamic selections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,9 @@ export default function CategoryTranslator() {
   const [subCategory1, setSubCategory1] = useState("");
   const [subCategory2, setSubCategory2] = useState("");
   const [subCategory3, setSubCategory3] = useState("");
+  const [options1, setOptions1] = useState([]);
+  const [options2, setOptions2] = useState([]);
+  const [options3, setOptions3] = useState([]);
 
   useEffect(() => {
     const categoryKeys = Object.keys(categoryData);
@@ -15,92 +18,166 @@ export default function CategoryTranslator() {
     setSelectedCategory(categoryKeys[0]);
   }, []);
 
-  const getTranslated = (level, path) => {
+  const getFirstLang = (cat) => Object.keys(categoryData[cat] || {})[0];
+
+  useEffect(() => {
+    if (!selectedCategory) {
+      setOptions1([]);
+      return;
+    }
+    const lang = getFirstLang(selectedCategory);
+    const children = categoryData[selectedCategory]?.[lang]?.children || {};
+    setOptions1(Object.keys(children));
+  }, [selectedCategory]);
+
+  useEffect(() => {
+    if (!selectedCategory || !subCategory1) {
+      setOptions2([]);
+      return;
+    }
+    const lang = getFirstLang(selectedCategory);
+    const child =
+      categoryData[selectedCategory]?.[lang]?.children?.[subCategory1] || {};
+    setOptions2(Object.keys(child.children || {}));
+  }, [selectedCategory, subCategory1]);
+
+  useEffect(() => {
+    if (!selectedCategory || !subCategory1 || !subCategory2) {
+      setOptions3([]);
+      return;
+    }
+    const lang = getFirstLang(selectedCategory);
+    const child =
+      categoryData[selectedCategory]?.[lang]?.children?.[subCategory1]?.children?.[
+        subCategory2
+      ] || {};
+    setOptions3(Object.keys(child.children || {}));
+  }, [selectedCategory, subCategory1, subCategory2]);
+
+  const getTranslated = (level) => {
+    const path = [subCategory1, subCategory2, subCategory3];
     let current = categoryData[selectedCategory]?.[language];
     if (!current) return "N/A";
     if (level === 1) return current.label;
-    if (level === 2) return current.children?.[path[0]]?.[language] || "N/A";
-    if (level === 3) return current.children?.[path[0]]?.children?.[path[1]]?.[language] || "N/A";
-    if (level === 4) return current.children?.[path[0]]?.children?.[path[1]]?.children?.[path[2]]?.[language] || "N/A";
-    return "N/A";
+    current = current.children?.[path[0]];
+    if (!current) return "N/A";
+    if (level === 2) return current[language] || "N/A";
+    current = current.children?.[path[1]];
+    if (!current) return "N/A";
+    if (level === 3) return current[language] || "N/A";
+    current = current.children?.[path[2]];
+    if (!current) return "N/A";
+    return current[language] || "N/A";
   };
 
   return (
     <div className="p-4 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-6 text-center">KDP Category Translator</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <label className="block mb-1 font-semibold">Category Level 1 (EN)</label>
-          <select
-            className="w-full p-2 border rounded mb-4"
-            value={selectedCategory}
-            onChange={(e) => {
-              setSelectedCategory(e.target.value);
-              setSubCategory1("");
-              setSubCategory2("");
-              setSubCategory3("");
-            }}
-          >
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>{cat}</option>
-            ))}
-          </select>
+        <div className="bg-white p-4 rounded shadow space-y-4">
+          <div>
+            <label className="block mb-1 font-semibold">Category Level 1 (EN)</label>
+            <select
+              className="w-full p-2 border rounded"
+              value={selectedCategory}
+              onChange={(e) => {
+                setSelectedCategory(e.target.value);
+                setSubCategory1("");
+                setSubCategory2("");
+                setSubCategory3("");
+              }}
+            >
+              {categories.map((cat) => (
+                <option key={cat} value={cat}>{cat}</option>
+              ))}
+            </select>
+          </div>
 
-          <label className="block mb-1 font-semibold">Category Level 2</label>
-          <input
-            type="text"
-            className="w-full p-2 border rounded mb-4"
-            value={subCategory1}
-            onChange={(e) => setSubCategory1(e.target.value)}
-            placeholder="(optional)"
-          />
+          {options1.length > 0 && (
+            <div>
+              <label className="block mb-1 font-semibold">Category Level 2 (EN)</label>
+              <select
+                className="w-full p-2 border rounded"
+                value={subCategory1}
+                onChange={(e) => {
+                  setSubCategory1(e.target.value);
+                  setSubCategory2("");
+                  setSubCategory3("");
+                }}
+              >
+                <option value="">Select...</option>
+                {options1.map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
-          <label className="block mb-1 font-semibold">Category Level 3</label>
-          <input
-            type="text"
-            className="w-full p-2 border rounded mb-4"
-            value={subCategory2}
-            onChange={(e) => setSubCategory2(e.target.value)}
-            placeholder="(optional)"
-          />
+          {options2.length > 0 && (
+            <div>
+              <label className="block mb-1 font-semibold">Category Level 3 (EN)</label>
+              <select
+                className="w-full p-2 border rounded"
+                value={subCategory2}
+                onChange={(e) => {
+                  setSubCategory2(e.target.value);
+                  setSubCategory3("");
+                }}
+              >
+                <option value="">Select...</option>
+                {options2.map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
-          <label className="block mb-1 font-semibold">Category Level 4</label>
-          <input
-            type="text"
-            className="w-full p-2 border rounded"
-            value={subCategory3}
-            onChange={(e) => setSubCategory3(e.target.value)}
-            placeholder="(optional)"
-          />
+          {options3.length > 0 && (
+            <div>
+              <label className="block mb-1 font-semibold">Category Level 4 (EN)</label>
+              <select
+                className="w-full p-2 border rounded"
+                value={subCategory3}
+                onChange={(e) => setSubCategory3(e.target.value)}
+              >
+                <option value="">Select...</option>
+                {options3.map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
 
-        <div>
-          <label className="block mb-1 font-semibold">Select Language</label>
-          <select
-            className="w-full p-2 border rounded mb-4"
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
-          >
-            <option value="de">German</option>
-            <option value="es">Spanish</option>
-            <option value="fr">French</option>
-            <option value="it">Italian</option>
-          </select>
+        <div className="bg-white p-4 rounded shadow space-y-4">
+          <div>
+            <label className="block mb-1 font-semibold">Select Language</label>
+            <select
+              className="w-full p-2 border rounded"
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+            >
+              <option value="de">German</option>
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+              <option value="it">Italian</option>
+            </select>
+          </div>
 
           <div className="p-4 bg-gray-100 rounded text-lg">
             <strong>Translated Category Level 1:</strong> <br /> {getTranslated(1)}
           </div>
 
-          <div className="mt-4 p-4 bg-gray-100 rounded text-lg">
-            <strong>Translated Category Level 2:</strong> <br /> {getTranslated(2, [subCategory1])}
+          <div className="p-4 bg-gray-100 rounded text-lg">
+            <strong>Translated Category Level 2:</strong> <br /> {getTranslated(2)}
           </div>
 
-          <div className="mt-4 p-4 bg-gray-100 rounded text-lg">
-            <strong>Translated Category Level 3:</strong> <br /> {getTranslated(3, [subCategory1, subCategory2])}
+          <div className="p-4 bg-gray-100 rounded text-lg">
+            <strong>Translated Category Level 3:</strong> <br /> {getTranslated(3)}
           </div>
 
-          <div className="mt-4 p-4 bg-gray-100 rounded text-lg">
-            <strong>Translated Category Level 4:</strong> <br /> {getTranslated(4, [subCategory1, subCategory2, subCategory3])}
+          <div className="p-4 bg-gray-100 rounded text-lg">
+            <strong>Translated Category Level 4:</strong> <br /> {getTranslated(4)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- enhance the category translator form layout
- add dropdowns for subcategory selection that update when higher levels change
- style the form columns with white background cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca193d2608329a4277f73f0d40189