### PR TITLE
Improve dark themed UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,7 +44,7 @@
 /* Custom styles for the category translator */
 
 .category-translator-container {
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
   font-family: sans-serif;
@@ -52,15 +52,16 @@
 
 .category-translator-title {
   text-align: center;
-  font-size: 1.75rem;
+  font-size: 2.5rem;
   font-weight: bold;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+  color: #fff;
 }
 
 .category-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1.5rem;
+  gap: 2rem;
 }
 
 @media (min-width: 768px) {
@@ -71,10 +72,11 @@
 
 .form-section,
 .result-section {
-  background: #393939;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: #2c2c2c;
+  padding: 2rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  min-height: 450px;
 }
 
 .form-group {
@@ -83,15 +85,18 @@
 
 .form-group label {
   display: block;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.5rem;
   font-weight: 600;
+  color: #ddd;
 }
 
 .form-control {
   width: 100%;
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid #555;
   border-radius: 4px;
+  background: #1a1a1a;
+  color: #fff;
 }
 
 .language-select {
@@ -99,9 +104,19 @@
 }
 
 .result-box {
-  background: #242424;
-  padding: 0.75rem;
+  background: #1e1e1e;
+  padding: 1rem;
   border-radius: 4px;
   font-size: 1rem;
   margin-bottom: 1rem;
+}
+
+.footer {
+  margin-top: 2rem;
+  text-align: center;
+  color: #888;
+}
+
+.footer a {
+  color: #646cff;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -182,6 +182,12 @@ export default function CategoryTranslator() {
           </div>
         </div>
       </div>
+      <footer className="footer">
+        Created by{' '}
+        <a href="https://twitter.com/yourtwitter" target="_blank" rel="noopener noreferrer">
+          @yourtwitter
+        </a>
+      </footer>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
@@ -54,15 +54,3 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
## Summary
- enlarge container blocks and adjust grid spacing
- update all inputs and titles for dark mode
- add footer with Twitter link
- enforce dark theme styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684ca5d206bc832984bb221eaada4d13