### PR TITLE
Align categories and move result titles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -59,25 +59,26 @@
 }
 
 .category-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.category-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 @media (min-width: 768px) {
-  .category-grid {
+  .category-row {
+    display: grid;
     grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    align-items: start;
   }
 }
 
-.form-section,
-.result-section {
-  background: #2c2c2c;
-  padding: 2rem;
-  border-radius: 10px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-  min-height: 450px;
-}
 
 .form-group {
   margin-bottom: 1rem;
@@ -103,12 +104,26 @@
   margin-bottom: 1rem;
 }
 
+.translation-group {
+  background: #2c2c2c;
+  padding: 1rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.result-title {
+  font-size: 0.9rem;
+  color: #ddd;
+  margin-bottom: 0.25rem;
+  text-align: left;
+}
+
 .result-box {
   background: #1e1e1e;
   padding: 1rem;
   border-radius: 4px;
   font-size: 1rem;
-  margin-bottom: 1rem;
+  margin: 0;
 }
 
 .footer {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,7 +75,21 @@ export default function CategoryTranslator() {
     <div className="category-translator-container">
       <h1 className="category-translator-title">KDP Category Translator</h1>
       <div className="category-grid">
-        <div className="form-section">
+        <div className="language-select">
+          <label>Select Language</label>
+          <select
+            className="form-control"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+          >
+            <option value="de">German</option>
+            <option value="es">Spanish</option>
+            <option value="fr">French</option>
+            <option value="it">Italian</option>
+          </select>
+        </div>
+
+        <div className="category-row">
           <div className="form-group">
             <label>Category Level 1 (EN)</label>
             <select
@@ -93,8 +107,14 @@ export default function CategoryTranslator() {
               ))}
             </select>
           </div>
+          <div className="translation-group">
+            <div className="result-title">Translated Category Level 1:</div>
+            <div className="result-box">{getTranslated(1)}</div>
+          </div>
+        </div>
 
-          {options1.length > 0 && (
+        {options1.length > 0 && (
+          <div className="category-row">
             <div className="form-group">
               <label>Category Level 2 (EN)</label>
               <select
@@ -112,9 +132,15 @@ export default function CategoryTranslator() {
                 ))}
               </select>
             </div>
-          )}
+            <div className="translation-group">
+              <div className="result-title">Translated Category Level 2:</div>
+              <div className="result-box">{getTranslated(2)}</div>
+            </div>
+          </div>
+        )}
 
-          {options2.length > 0 && (
+        {options2.length > 0 && (
+          <div className="category-row">
             <div className="form-group">
               <label>Category Level 3 (EN)</label>
               <select
@@ -131,9 +157,15 @@ export default function CategoryTranslator() {
                 ))}
               </select>
             </div>
-          )}
+            <div className="translation-group">
+              <div className="result-title">Translated Category Level 3:</div>
+              <div className="result-box">{getTranslated(3)}</div>
+            </div>
+          </div>
+        )}
 
-          {options3.length > 0 && (
+        {options3.length > 0 && (
+          <div className="category-row">
             <div className="form-group">
               <label>Category Level 4 (EN)</label>
               <select
@@ -147,40 +179,12 @@ export default function CategoryTranslator() {
                 ))}
               </select>
             </div>
-          )}
-        </div>
-
-        <div className="result-section">
-          <div className="language-select">
-            <label>Select Language</label>
-            <select
-              className="form-control"
-              value={language}
-              onChange={(e) => setLanguage(e.target.value)}
-            >
-              <option value="de">German</option>
-              <option value="es">Spanish</option>
-              <option value="fr">French</option>
-              <option value="it">Italian</option>
-            </select>
+            <div className="translation-group">
+              <div className="result-title">Translated Category Level 4:</div>
+              <div className="result-box">{getTranslated(4)}</div>
+            </div>
           </div>
-
-          <div className="result-box">
-            <strong>Translated Category Level 1:</strong> <br /> {getTranslated(1)}
-          </div>
-
-          <div className="result-box">
-            <strong>Translated Category Level 2:</strong> <br /> {getTranslated(2)}
-          </div>
-
-          <div className="result-box">
-            <strong>Translated Category Level 3:</strong> <br /> {getTranslated(3)}
-          </div>
-
-          <div className="result-box">
-            <strong>Translated Category Level 4:</strong> <br /> {getTranslated(4)}
-          </div>
-        </div>
+        )}
       </div>
       <footer className="footer">
         Created by{' '}


### PR DESCRIPTION
## Summary
- adjust category UI layout
- place translated category titles above the result
- align each level between languages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cabb3d08c83298de9e9fe1ddb7c83