### PR TITLE
Add arrows and conditional category results

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,9 +74,9 @@
 @media (min-width: 768px) {
   .category-row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr auto 1fr;
     gap: 1rem;
-    align-items: start;
+    align-items: center;
   }
 }
 
@@ -134,6 +134,12 @@
   border-radius: 4px;
   font-size: 1rem;
   margin: 0;
+}
+
+.arrow {
+  color: #fff;
+  font-size: 1.25rem;
+  margin: 0 0.5rem;
 }
 
 .footer {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,6 @@ export default function CategoryTranslator() {
   useEffect(() => {
     const categoryKeys = Object.keys(categoryData);
     setCategories(categoryKeys);
-    setSelectedCategory(categoryKeys[0]);
   }, []);
 
   const getFirstLang = (cat) => Object.keys(categoryData[cat] || {})[0];
@@ -102,15 +101,21 @@ export default function CategoryTranslator() {
                 setSubCategory3("");
               }}
             >
+              <option value="">Select...</option>
               {categories.map((cat) => (
                 <option key={cat} value={cat}>{cat}</option>
               ))}
             </select>
           </div>
-          <div className="translation-group">
-            <div className="result-title">Translated Category Level 1:</div>
-            <div className="result-box">{getTranslated(1)}</div>
-          </div>
+          {selectedCategory && (
+            <>
+              <div className="arrow">→ Resultado</div>
+              <div className="translation-group">
+                <div className="result-title">Translated Category Level 1:</div>
+                <div className="result-box">{getTranslated(1)}</div>
+              </div>
+            </>
+          )}
         </div>
 
         {options1.length > 0 && (
@@ -132,10 +137,15 @@ export default function CategoryTranslator() {
                 ))}
               </select>
             </div>
-            <div className="translation-group">
-              <div className="result-title">Translated Category Level 2:</div>
-              <div className="result-box">{getTranslated(2)}</div>
-            </div>
+            {subCategory1 && (
+              <>
+                <div className="arrow">→ Resultado</div>
+                <div className="translation-group">
+                  <div className="result-title">Translated Category Level 2:</div>
+                  <div className="result-box">{getTranslated(2)}</div>
+                </div>
+              </>
+            )}
           </div>
         )}
 
@@ -157,10 +167,15 @@ export default function CategoryTranslator() {
                 ))}
               </select>
             </div>
-            <div className="translation-group">
-              <div className="result-title">Translated Category Level 3:</div>
-              <div className="result-box">{getTranslated(3)}</div>
-            </div>
+            {subCategory2 && (
+              <>
+                <div className="arrow">→ Resultado</div>
+                <div className="translation-group">
+                  <div className="result-title">Translated Category Level 3:</div>
+                  <div className="result-box">{getTranslated(3)}</div>
+                </div>
+              </>
+            )}
           </div>
         )}
 
@@ -179,10 +194,15 @@ export default function CategoryTranslator() {
                 ))}
               </select>
             </div>
-            <div className="translation-group">
-              <div className="result-title">Translated Category Level 4:</div>
-              <div className="result-box">{getTranslated(4)}</div>
-            </div>
+            {subCategory3 && (
+              <>
+                <div className="arrow">→ Resultado</div>
+                <div className="translation-group">
+                  <div className="result-title">Translated Category Level 4:</div>
+                  <div className="result-box">{getTranslated(4)}</div>
+                </div>
+              </>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- show selects as blank until user chooses
- display results only when a category is chosen
- add right arrow indicator between selections and their translations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cb146e71c832990f8eb332c2cee17