### PR TITLE
Update KDP category prompt

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,9 @@ export default function CategoryTranslator() {
 
     const apiKey = "import.meta.env.VITE_GEMINI_API_KEY";
     const prompt =
-      `Provide the equivalent Amazon KDP category path in ${language} for: ${path}`;
+      `You are an expert publisher specialized in marketing and KDP. ` +
+      `Give the three closest equivalent Amazon KDP category paths in ${language} for: ${path}. ` +
+      `Format each option as [Cat1,Cat2,Cat3].`;
 
     try {
       setLoading(true);


### PR DESCRIPTION
## Summary
- refine the Gemini API prompt so it references an expert publisher
- request three closest categories formatted as `[Cat1,Cat2,Cat3]`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68502bc348d483298749254532c19d5a