### PR TITLE
Improve layout and style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -45,9 +45,12 @@
 
 .category-translator-container {
   max-width: 1200px;
-  margin: 0 auto;
+  margin: 2rem auto;
   padding: 2rem;
   font-family: sans-serif;
+  background: #1a1a1a;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
 
 .category-translator-title {
@@ -55,14 +58,22 @@
   font-size: 2.5rem;
   font-weight: bold;
   margin-bottom: 2rem;
-  color: #fff;
+  background: linear-gradient(90deg, #fff, #bbb);
+  -webkit-background-clip: text;
+  color: transparent;
 }
 
 .category-grid {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  min-width: 800px;
+  gap: 2rem;
+}
+
+.left-column,
+.right-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .category-row {
@@ -72,11 +83,14 @@
 }
 
 @media (min-width: 768px) {
-  .category-row {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    gap: 1rem;
-    align-items: center;
+  .category-grid {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .left-column,
+  .right-column {
+    flex: 1;
   }
 }
 
@@ -133,10 +147,13 @@
   border-radius: 4px;
   font-size: 1rem;
   margin: 0;
+  white-space: pre-wrap;
 }
 
 .search-button {
-  margin-top: 1rem;
+  margin: 2rem auto 0;
+  padding: 0.8rem 2rem;
+  font-size: 1.1rem;
 }
 
 .arrow {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,46 +56,50 @@ export default function CategoryTranslator() {
     <div className="category-translator-container">
       <h1 className="category-translator-title">KDP Category Translator</h1>
       <div className="category-grid">
-        <div className="language-select">
-          <label>Select Language</label>
-          <select
-            className="form-control"
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
-          >
-            <option value="de">German</option>
-            <option value="es">Spanish</option>
-            <option value="fr">French</option>
-            <option value="it">Italian</option>
-          </select>
+        <div className="left-column">
+          {levels.map((lvl, idx) => (
+            <div className="category-row" key={idx}>
+              <div className="form-group">
+                <label>{`Level ${idx + 1} (EN)`}</label>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={lvl}
+                  onChange={(e) => handleChange(idx, e.target.value)}
+                  placeholder={`Level ${idx + 1}`}
+                />
+              </div>
+            </div>
+          ))}
         </div>
 
-        {levels.map((lvl, idx) => (
-          <div className="category-row" key={idx}>
-            <div className="form-group">
-              <label>{`Level ${idx + 1} (EN)`}</label>
-              <input
-                className="form-control"
-                type="text"
-                value={lvl}
-                onChange={(e) => handleChange(idx, e.target.value)}
-                placeholder={`Level ${idx + 1}`}
-              />
+        <div className="right-column">
+          <div className="language-select">
+            <label>Select Language</label>
+            <select
+              className="form-control"
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+            >
+              <option value="de">German</option>
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+              <option value="it">Italian</option>
+            </select>
+          </div>
+
+          {result && (
+            <div className="translation-group">
+              <div className="result-title">Result</div>
+              <div className="result-box">{result}</div>
             </div>
-          </div>
-        ))}
-
-        <button className="search-button" onClick={translate} disabled={loading}>
-          {loading ? "Loading..." : "Search"}
-        </button>
-
-        {result && (
-          <div className="translation-group">
-            <div className="result-title">Result</div>
-            <div className="result-box">{result}</div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
+
+      <button className="search-button" onClick={translate} disabled={loading}>
+        {loading ? "Loading..." : "Search"}
+      </button>
       <footer className="footer">
         Created by{' '}
         <a href="https://twitter.com/CactusGuica" target="_blank" rel="noopener noreferrer">

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
   color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background: radial-gradient(circle at top left, #333, #1a1a1a);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
- restructure layout to show category fields on the left and result/language on the right
- place search button below the two columns
- restyle page with dark gradient background and updated components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68503c3e67b88329a5add2e76670d95d