### PR TITLE
Improve style and results

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -141,19 +141,32 @@
 
 }
 
+.result-options {
+  display: flex;
+  gap: 1rem;
+}
+
 .result-box {
   background: #1e1e1e;
   padding: 1rem;
   border-radius: 4px;
+  border: 1px solid var(--accent-color);
   font-size: 1rem;
   margin: 0;
   white-space: pre-wrap;
+  flex: 1;
 }
 
 .search-button {
   margin: 2rem auto 0;
   padding: 0.8rem 2rem;
   font-size: 1.1rem;
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+}
+.search-button:hover {
+  background: #ffa54d;
 }
 
 .arrow {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import "./App.css";
 export default function CategoryTranslator() {
   const [language, setLanguage] = useState("de");
   const [levels, setLevels] = useState(["", "", "", ""]);
-  const [result, setResult] = useState("");
+  const [results, setResults] = useState(["", "", ""]);
   const [loading, setLoading] = useState(false);
 
   const handleChange = (index, value) => {
@@ -42,11 +42,19 @@ export default function CategoryTranslator() {
       );
       const data = await response.json();
       const text =
-        data.candidates?.[0]?.content?.parts?.[0]?.text || "N/A";
-      setResult(text);
+        data.candidates?.[0]?.content?.parts?.[0]?.text || "";
+
+      const opts = [];
+      const regex = /Option\s*\d+[:.-]\s*(.*)/gi;
+      let match;
+      while ((match = regex.exec(text)) && opts.length < 3) {
+        opts.push(match[1].trim());
+      }
+      while (opts.length < 3) opts.push("");
+      setResults(opts);
     } catch (err) {
       console.error(err);
-      setResult("Error retrieving translation");
+      setResults(["Error", "retrieving", "translation"]);
     } finally {
       setLoading(false);
     }
@@ -88,12 +96,16 @@ export default function CategoryTranslator() {
             </select>
           </div>
 
-          {result && (
-            <div className="translation-group">
-              <div className="result-title">Result</div>
-              <div className="result-box">{result}</div>
+          <div className="translation-group">
+            <div className="result-title">Result</div>
+            <div className="result-options">
+              {results.map((res, idx) => (
+                <div key={idx} className="result-box">
+                  {res || "-"}
+                </div>
+              ))}
             </div>
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
+  --accent-color: #ff7a00;
+
   color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
   background: radial-gradient(circle at top left, #333, #1a1a1a);
@@ -15,11 +17,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--accent-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #ffa54d;
 }
 
 body {
@@ -47,7 +49,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--accent-color);
 }
 button:focus,
 button:focus-visible {


### PR DESCRIPTION
## Summary
- add orange accent theme
- style search button and results
- keep the result area visible and parse API output into three blocks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68503e09cc048329ac96a09255769eca